### PR TITLE
Move generic recipes to the end

### DIFF
--- a/.github/workflows/golangci-lint-runner.yml
+++ b/.github/workflows/golangci-lint-runner.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: linter
-        uses: "docker://talononedevs/golangci-lint-runner@sha256:2e00aaabc35fe2253e78ec593f96b3a787081007fdcccc0a633ab1f46375dab0"
+        uses: "docker://talononedevs/golangci-lint-runner:latest"
         with:
           entrypoint: /bin/golangci-lint-runner
           args: standalone

--- a/.github/workflows/golangci-lint-runner.yml
+++ b/.github/workflows/golangci-lint-runner.yml
@@ -10,8 +10,8 @@ jobs:
           entrypoint: /bin/golangci-lint-runner
           args: standalone
         env:
-          APPROVE: true
-          REQUEST_CHANGES: true
+          APPROVE: false
+          REQUEST_CHANGES: false
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           NO_ISSUES_TEXT: "No issues found"
           NO_CHANGES_TEXT: "No issues found"

--- a/convert.go
+++ b/convert.go
@@ -86,10 +86,31 @@ func (conv defaultConverter) ConvertReflectValue(src, dst reflect.Value, options
 
 	if len(options) > 0 {
 		conv.options.SkipUnknownFields = options[0].SkipUnknownFields
-		conv.options.Recipes = append(options[0].Recipes, conv.options.Recipes...)
+		conv.options.Recipes = appendRecipes(conv.options.Recipes, options[0].Recipes)
 	}
 
 	return conv.convertNow(src, dst, out, options...)
+}
+
+func appendRecipes(recipes, customRecipes []Recipe) []Recipe {
+	var normalRecipes []Recipe
+	var genericRecipes []Recipe
+	for i := range customRecipes {
+		if isGenericType(customRecipes[i].From) || isGenericType(customRecipes[i].To) {
+			genericRecipes = append(genericRecipes, customRecipes[i])
+			continue
+		}
+		normalRecipes = append(normalRecipes, customRecipes[i])
+	}
+	for i := range recipes {
+		if isGenericType(recipes[i].From) || isGenericType(recipes[i].To) {
+			genericRecipes = append(genericRecipes, recipes[i])
+			continue
+		}
+		normalRecipes = append(normalRecipes, recipes[i])
+	}
+
+	return append(normalRecipes, genericRecipes...)
 }
 
 func (conv defaultConverter) convertNow(src, dst, out reflect.Value, options ...Options) error {
@@ -191,7 +212,7 @@ func New(options ...Options) Converter {
 	conv := defaultConverterInstance
 	if len(options) > 0 {
 		conv.options.SkipUnknownFields = options[0].SkipUnknownFields
-		conv.options.Recipes = append(options[0].Recipes, conv.options.Recipes...)
+		conv.options.Recipes = appendRecipes(conv.options.Recipes, options[0].Recipes)
 	}
 	return &conv
 }

--- a/converter.go
+++ b/converter.go
@@ -34,3 +34,17 @@ type Converter interface {
 	ConvertReflectValue(src, dst reflect.Value, options ...Options) error
 	MustConvertReflectValue(src, dst reflect.Value, options ...Options)
 }
+
+func isGenericType(t reflect.Type) bool {
+	switch t {
+	case NilType:
+		return true
+	case MapType:
+		return true
+	case StructType:
+		return true
+	case SliceType:
+		return true
+	}
+	return false
+}

--- a/float32.go
+++ b/float32.go
@@ -2,6 +2,7 @@ package convert
 
 import (
 	"strconv"
+	"time"
 )
 
 func (stdRecipes) intToFloat32(c Converter, in int, out *float32) error {
@@ -72,5 +73,10 @@ func (stdRecipes) stringToFloat32(c Converter, in string, out *float32) error {
 		return err
 	}
 	*out = float32(i)
+	return nil
+}
+
+func (stdRecipes) timeToFloat32(c Converter, in time.Time, out *float32) error {
+	*out = float32(in.Unix())
 	return nil
 }

--- a/float32_test.go
+++ b/float32_test.go
@@ -3,6 +3,8 @@ package convert_test
 import (
 	"testing"
 
+	"time"
+
 	"github.com/Eun/go-convert/internal/testhelpers"
 )
 
@@ -48,6 +50,8 @@ func TestFloat32(t *testing.T) {
 		{[]string{"H", "e", "l", "l", "o"}, float32(0), float32(0), "unable to convert []string to float32: no recipe", nil},
 		// struct
 		{struct{}{}, float32(0), float32(0), "unable to convert struct {} to float32: no recipe", nil},
+		// time
+		{time.Unix(10, 10), float32(10), float32(10), "", nil},
 	}
 
 	for i, test := range tests {

--- a/float64.go
+++ b/float64.go
@@ -77,6 +77,6 @@ func (stdRecipes) stringToFloat64(c Converter, in string, out *float64) error {
 }
 
 func (stdRecipes) timeToFloat64(c Converter, in time.Time, out *float64) error {
-	*out = float64(float64(in.Unix()) + float64(in.Nanosecond())/1000000000)
+	*out = float64(in.Unix()) + float64(in.Nanosecond())/1000000000
 	return nil
 }

--- a/float64.go
+++ b/float64.go
@@ -2,6 +2,7 @@ package convert
 
 import (
 	"strconv"
+	"time"
 )
 
 func (stdRecipes) intToFloat64(c Converter, in int, out *float64) error {
@@ -72,5 +73,10 @@ func (stdRecipes) stringToFloat64(c Converter, in string, out *float64) error {
 		return err
 	}
 	*out = i
+	return nil
+}
+
+func (stdRecipes) timeToFloat64(c Converter, in time.Time, out *float64) error {
+	*out = float64(float64(in.Unix()) + float64(in.Nanosecond())/1000000000)
 	return nil
 }

--- a/float64_test.go
+++ b/float64_test.go
@@ -3,6 +3,8 @@ package convert_test
 import (
 	"testing"
 
+	"time"
+
 	"github.com/Eun/go-convert/internal/testhelpers"
 )
 
@@ -48,6 +50,8 @@ func TestFloat64(t *testing.T) {
 		{[]string{"H", "e", "l", "l", "o"}, float64(0), float64(0), "unable to convert []string to float64: no recipe", nil},
 		// struct
 		{struct{}{}, float64(0), float64(0), "unable to convert struct {} to float64: no recipe", nil},
+		// time
+		{time.Unix(10, 10), float64(10.00000001), float64(10.00000001), "", nil},
 	}
 
 	for i, test := range tests {

--- a/int.go
+++ b/int.go
@@ -2,6 +2,7 @@ package convert
 
 import (
 	"strconv"
+	"time"
 )
 
 func (stdRecipes) intToInt(c Converter, in int, out *int) error {
@@ -72,5 +73,9 @@ func (stdRecipes) stringToInt(c Converter, in string, out *int) error {
 		return err
 	}
 	*out = int(i)
+	return nil
+}
+func (stdRecipes) timeToInt(c Converter, in time.Time, out *int) error {
+	*out = int(in.Unix())
 	return nil
 }

--- a/int16.go
+++ b/int16.go
@@ -2,6 +2,7 @@ package convert
 
 import (
 	"strconv"
+	"time"
 )
 
 func (stdRecipes) intToInt16(c Converter, in int, out *int16) error {
@@ -72,5 +73,9 @@ func (stdRecipes) stringToInt16(c Converter, in string, out *int16) error {
 		return err
 	}
 	*out = int16(i)
+	return nil
+}
+func (stdRecipes) timeToInt16(c Converter, in time.Time, out *int16) error {
+	*out = int16(in.Unix())
 	return nil
 }

--- a/int16_test.go
+++ b/int16_test.go
@@ -3,6 +3,8 @@ package convert_test
 import (
 	"testing"
 
+	"time"
+
 	"github.com/Eun/go-convert/internal/testhelpers"
 )
 
@@ -48,6 +50,8 @@ func TestInt16(t *testing.T) {
 		{[]string{"H", "e", "l", "l", "o"}, int16(0), int16(0), "unable to convert []string to int16: no recipe", nil},
 		// struct
 		{struct{}{}, int16(0), int16(0), "unable to convert struct {} to int16: no recipe", nil},
+		// time
+		{time.Unix(10, 10), int16(10), int16(10), "", nil},
 	}
 
 	for i, test := range tests {

--- a/int32.go
+++ b/int32.go
@@ -2,6 +2,7 @@ package convert
 
 import (
 	"strconv"
+	"time"
 )
 
 func (stdRecipes) intToInt32(c Converter, in int, out *int32) error {
@@ -72,5 +73,9 @@ func (stdRecipes) stringToInt32(c Converter, in string, out *int32) error {
 		return err
 	}
 	*out = int32(i)
+	return nil
+}
+func (stdRecipes) timeToInt32(c Converter, in time.Time, out *int32) error {
+	*out = int32(in.Unix())
 	return nil
 }

--- a/int32_test.go
+++ b/int32_test.go
@@ -3,6 +3,8 @@ package convert_test
 import (
 	"testing"
 
+	"time"
+
 	"github.com/Eun/go-convert/internal/testhelpers"
 )
 
@@ -48,6 +50,8 @@ func TestInt32(t *testing.T) {
 		{[]string{"H", "e", "l", "l", "o"}, int32(0), int32(0), "unable to convert []string to int32: no recipe", nil},
 		// struct
 		{struct{}{}, int32(0), int32(0), "unable to convert struct {} to int32: no recipe", nil},
+		// time
+		{time.Unix(10, 10), int32(10), int32(10), "", nil},
 	}
 
 	for i, test := range tests {

--- a/int64.go
+++ b/int64.go
@@ -2,6 +2,7 @@ package convert
 
 import (
 	"strconv"
+	"time"
 )
 
 func (stdRecipes) intToInt64(c Converter, in int, out *int64) error {
@@ -72,5 +73,9 @@ func (stdRecipes) stringToInt64(c Converter, in string, out *int64) error {
 		return err
 	}
 	*out = i
+	return nil
+}
+func (stdRecipes) timeToInt64(c Converter, in time.Time, out *int64) error {
+	*out = int64(in.Unix())
 	return nil
 }

--- a/int64.go
+++ b/int64.go
@@ -76,6 +76,6 @@ func (stdRecipes) stringToInt64(c Converter, in string, out *int64) error {
 	return nil
 }
 func (stdRecipes) timeToInt64(c Converter, in time.Time, out *int64) error {
-	*out = int64(in.Unix())
+	*out = in.Unix()
 	return nil
 }

--- a/int64_test.go
+++ b/int64_test.go
@@ -3,6 +3,8 @@ package convert_test
 import (
 	"testing"
 
+	"time"
+
 	"github.com/Eun/go-convert/internal/testhelpers"
 )
 
@@ -48,6 +50,8 @@ func TestInt64(t *testing.T) {
 		{[]string{"H", "e", "l", "l", "o"}, int64(0), int64(0), "unable to convert []string to int64: no recipe", nil},
 		// struct
 		{struct{}{}, int64(0), int64(0), "unable to convert struct {} to int64: no recipe", nil},
+		// time
+		{time.Unix(10, 10), int64(10), int64(10), "", nil},
 	}
 
 	for i, test := range tests {

--- a/int8.go
+++ b/int8.go
@@ -2,6 +2,7 @@ package convert
 
 import (
 	"strconv"
+	"time"
 )
 
 func (stdRecipes) intToInt8(c Converter, in int, out *int8) error {
@@ -72,5 +73,9 @@ func (stdRecipes) stringToInt8(c Converter, in string, out *int8) error {
 		return err
 	}
 	*out = int8(i)
+	return nil
+}
+func (stdRecipes) timeToInt8(c Converter, in time.Time, out *int8) error {
+	*out = int8(in.Unix())
 	return nil
 }

--- a/int8_test.go
+++ b/int8_test.go
@@ -3,6 +3,8 @@ package convert_test
 import (
 	"testing"
 
+	"time"
+
 	"github.com/Eun/go-convert/internal/testhelpers"
 )
 
@@ -48,6 +50,8 @@ func TestInt8(t *testing.T) {
 		{[]string{"H", "e", "l", "l", "o"}, int8(0), int8(0), "unable to convert []string to int8: no recipe", nil},
 		// struct
 		{struct{}{}, int8(0), int8(0), "unable to convert struct {} to int8: no recipe", nil},
+		// time
+		{time.Unix(10, 10), int8(10), int8(10), "", nil},
 	}
 
 	for i, test := range tests {

--- a/int_test.go
+++ b/int_test.go
@@ -2,6 +2,7 @@ package convert_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/Eun/go-convert/internal/testhelpers"
 )
@@ -48,6 +49,8 @@ func TestInt(t *testing.T) {
 		{[]string{"H", "e", "l", "l", "o"}, 0, 0, "unable to convert []string to int: no recipe", nil},
 		// struct
 		{struct{}{}, 0, 0, "unable to convert struct {} to int: no recipe", nil},
+		// time
+		{time.Unix(10, 10), int(10), int(10), "", nil},
 	}
 
 	for i, test := range tests {

--- a/recipe_test.go
+++ b/recipe_test.go
@@ -70,3 +70,154 @@ func TestMustMakeRecipe(t *testing.T) {
 		_ = MustMakeRecipe(0)
 	})
 }
+
+func TestJoinRecipes(t *testing.T) {
+	tests := []struct {
+		Recipes       []Recipe
+		CustomRecipes []Recipe
+		Wanted        []Recipe
+	}{
+		{
+			[]Recipe{
+				{
+					From: reflect.TypeOf(""),
+					To:   reflect.TypeOf(""),
+				},
+			},
+			[]Recipe{
+				{
+					From: reflect.TypeOf(0),
+					To:   reflect.TypeOf(0),
+				},
+			},
+			[]Recipe{
+				{
+					From: reflect.TypeOf(0),
+					To:   reflect.TypeOf(0),
+				},
+				{
+					From: reflect.TypeOf(""),
+					To:   reflect.TypeOf(""),
+				},
+			},
+		},
+
+		{
+			[]Recipe{
+				{
+					From: NilType,
+					To:   reflect.TypeOf(""),
+				},
+			},
+			[]Recipe{
+				{
+					From: StructType,
+					To:   reflect.TypeOf(0),
+				},
+			},
+			[]Recipe{
+				{
+					From: StructType,
+					To:   reflect.TypeOf(0),
+				},
+				{
+					From: NilType,
+					To:   reflect.TypeOf(""),
+				},
+			},
+		},
+
+		{
+			[]Recipe{
+				{
+					From: NilType,
+					To:   reflect.TypeOf(""),
+				},
+			},
+			[]Recipe{
+				{
+					From: reflect.TypeOf(0),
+					To:   reflect.TypeOf(0),
+				},
+				{
+					From: StructType,
+					To:   reflect.TypeOf(""),
+				},
+			},
+			[]Recipe{
+				{
+					From: reflect.TypeOf(0),
+					To:   reflect.TypeOf(0),
+				},
+				{
+					From: StructType,
+					To:   reflect.TypeOf(""),
+				},
+				{
+					From: NilType,
+					To:   reflect.TypeOf(""),
+				},
+			},
+		},
+
+		{
+			[]Recipe{
+				{
+					From: reflect.TypeOf(""),
+					To:   reflect.TypeOf(""),
+				},
+				{
+					From: NilType,
+					To:   reflect.TypeOf(""),
+				},
+			},
+			[]Recipe{
+				{
+					From: reflect.TypeOf(0),
+					To:   reflect.TypeOf(0),
+				},
+				{
+					From: StructType,
+					To:   reflect.TypeOf(""),
+				},
+			},
+			[]Recipe{
+				{
+					From: reflect.TypeOf(0),
+					To:   reflect.TypeOf(0),
+				},
+				{
+					From: reflect.TypeOf(""),
+					To:   reflect.TypeOf(""),
+				},
+				{
+					From: StructType,
+					To:   reflect.TypeOf(""),
+				},
+				{
+					From: NilType,
+					To:   reflect.TypeOf(""),
+				},
+			},
+		},
+
+		// when this test fails it means that the standart recipes are not in order
+		// make sure generic types are on the end
+		{
+			getStdRecipes(),
+			nil,
+			getStdRecipes(),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run("", func(t *testing.T) {
+			recipes := joinRecipes(test.Recipes, test.CustomRecipes)
+			require.Equal(t, len(test.Wanted), len(recipes))
+			for i := range recipes {
+				require.Equal(t, test.Wanted[i].From, recipes[i].From)
+				require.Equal(t, test.Wanted[i].To, recipes[i].To)
+			}
+		})
+	}
+}

--- a/recipes.go
+++ b/recipes.go
@@ -10,7 +10,6 @@ func getStdRecipes() []Recipe {
 	var r stdRecipes
 	var s string
 	return []Recipe{
-
 		// bool
 		MustMakeRecipe(r.intToBool),
 		MustMakeRecipe(r.int8ToBool),
@@ -42,6 +41,7 @@ func getStdRecipes() []Recipe {
 		MustMakeRecipe(r.float32ToFloat32),
 		MustMakeRecipe(r.float64ToFloat32),
 		MustMakeRecipe(r.stringToFloat32),
+		MustMakeRecipe(r.timeToFloat32),
 
 		// float64
 		MustMakeRecipe(r.intToFloat64),
@@ -58,6 +58,7 @@ func getStdRecipes() []Recipe {
 		MustMakeRecipe(r.float32ToFloat64),
 		MustMakeRecipe(r.float64ToFloat64),
 		MustMakeRecipe(r.stringToFloat64),
+		MustMakeRecipe(r.timeToFloat64),
 
 		// int
 		MustMakeRecipe(r.intToInt),
@@ -74,6 +75,7 @@ func getStdRecipes() []Recipe {
 		MustMakeRecipe(r.float32ToInt),
 		MustMakeRecipe(r.float64ToInt),
 		MustMakeRecipe(r.stringToInt),
+		MustMakeRecipe(r.timeToInt),
 
 		// int8
 		MustMakeRecipe(r.intToInt8),
@@ -90,6 +92,7 @@ func getStdRecipes() []Recipe {
 		MustMakeRecipe(r.float32ToInt8),
 		MustMakeRecipe(r.float64ToInt8),
 		MustMakeRecipe(r.stringToInt8),
+		MustMakeRecipe(r.timeToInt8),
 
 		// int16
 		MustMakeRecipe(r.intToInt16),
@@ -106,6 +109,7 @@ func getStdRecipes() []Recipe {
 		MustMakeRecipe(r.float32ToInt16),
 		MustMakeRecipe(r.float64ToInt16),
 		MustMakeRecipe(r.stringToInt16),
+		MustMakeRecipe(r.timeToInt16),
 
 		// int32
 		MustMakeRecipe(r.intToInt32),
@@ -122,6 +126,7 @@ func getStdRecipes() []Recipe {
 		MustMakeRecipe(r.float32ToInt32),
 		MustMakeRecipe(r.float64ToInt32),
 		MustMakeRecipe(r.stringToInt32),
+		MustMakeRecipe(r.timeToInt32),
 
 		// int64
 		MustMakeRecipe(r.intToInt64),
@@ -138,6 +143,7 @@ func getStdRecipes() []Recipe {
 		MustMakeRecipe(r.float32ToInt64),
 		MustMakeRecipe(r.float64ToInt64),
 		MustMakeRecipe(r.stringToInt64),
+		MustMakeRecipe(r.timeToInt64),
 
 		// map
 		{
@@ -149,23 +155,6 @@ func getStdRecipes() []Recipe {
 			From: StructType,
 			To:   MapType,
 			Func: r.structToMap,
-		},
-
-		// slice
-		{
-			From: reflect.TypeOf(""),
-			To:   SliceType,
-			Func: r.stringToSlice,
-		},
-		{
-			From: SliceType,
-			To:   SliceType,
-			Func: r.sliceToSlice,
-		},
-		{
-			From: NilType,
-			To:   SliceType,
-			Func: r.nilToSlice,
 		},
 
 		// string
@@ -193,10 +182,41 @@ func getStdRecipes() []Recipe {
 		MustMakeRecipe(r.uint16SliceToString),
 		MustMakeRecipe(r.uint32SliceToString),
 		MustMakeRecipe(r.uint64SliceToString),
+		MustMakeRecipe(r.timeToString),
+
 		{
 			From: StructType,
 			To:   reflect.TypeOf(&s),
 			Func: r.structToString,
+		},
+
+		// slice
+		{
+			From: reflect.TypeOf(""),
+			To:   SliceType,
+			Func: r.stringToSlice,
+		},
+		{
+			From: SliceType,
+			To:   SliceType,
+			Func: r.sliceToSlice,
+		},
+		{
+			From: NilType,
+			To:   SliceType,
+			Func: r.nilToSlice,
+		},
+
+		// struct
+		{
+			From: MapType,
+			To:   StructType,
+			Func: r.mapToStruct,
+		},
+		{
+			From: StructType,
+			To:   StructType,
+			Func: r.structToStruct,
 		},
 
 		// time
@@ -229,6 +249,7 @@ func getStdRecipes() []Recipe {
 		MustMakeRecipe(r.float32ToUint),
 		MustMakeRecipe(r.float64ToUint),
 		MustMakeRecipe(r.stringToUint),
+		MustMakeRecipe(r.timeToUint),
 
 		// uint8
 		MustMakeRecipe(r.intToUint8),
@@ -245,6 +266,7 @@ func getStdRecipes() []Recipe {
 		MustMakeRecipe(r.float32ToUint8),
 		MustMakeRecipe(r.float64ToUint8),
 		MustMakeRecipe(r.stringToUint8),
+		MustMakeRecipe(r.timeToUint8),
 
 		// uint16
 		MustMakeRecipe(r.intToUint16),
@@ -261,6 +283,7 @@ func getStdRecipes() []Recipe {
 		MustMakeRecipe(r.float32ToUint16),
 		MustMakeRecipe(r.float64ToUint16),
 		MustMakeRecipe(r.stringToUint16),
+		MustMakeRecipe(r.timeToUint16),
 
 		// uint32
 		MustMakeRecipe(r.intToUint32),
@@ -277,6 +300,7 @@ func getStdRecipes() []Recipe {
 		MustMakeRecipe(r.float32ToUint32),
 		MustMakeRecipe(r.float64ToUint32),
 		MustMakeRecipe(r.stringToUint32),
+		MustMakeRecipe(r.timeToUint32),
 
 		// uint64
 		MustMakeRecipe(r.intToUint64),
@@ -293,17 +317,6 @@ func getStdRecipes() []Recipe {
 		MustMakeRecipe(r.float32ToUint64),
 		MustMakeRecipe(r.float64ToUint64),
 		MustMakeRecipe(r.stringToUint64),
-
-		// struct (last resort)
-		{
-			From: MapType,
-			To:   StructType,
-			Func: r.mapToStruct,
-		},
-		{
-			From: StructType,
-			To:   StructType,
-			Func: r.structToStruct,
-		},
+		MustMakeRecipe(r.timeToUint64),
 	}
 }

--- a/recipes.go
+++ b/recipes.go
@@ -145,18 +145,6 @@ func getStdRecipes() []Recipe {
 		MustMakeRecipe(r.stringToInt64),
 		MustMakeRecipe(r.timeToInt64),
 
-		// map
-		{
-			From: MapType,
-			To:   MapType,
-			Func: r.mapToMap,
-		},
-		{
-			From: StructType,
-			To:   MapType,
-			Func: r.structToMap,
-		},
-
 		// string
 		MustMakeRecipe(r.intToString),
 		MustMakeRecipe(r.int8ToString),
@@ -183,41 +171,6 @@ func getStdRecipes() []Recipe {
 		MustMakeRecipe(r.uint32SliceToString),
 		MustMakeRecipe(r.uint64SliceToString),
 		MustMakeRecipe(r.timeToString),
-
-		{
-			From: StructType,
-			To:   reflect.TypeOf(&s),
-			Func: r.structToString,
-		},
-
-		// slice
-		{
-			From: reflect.TypeOf(""),
-			To:   SliceType,
-			Func: r.stringToSlice,
-		},
-		{
-			From: SliceType,
-			To:   SliceType,
-			Func: r.sliceToSlice,
-		},
-		{
-			From: NilType,
-			To:   SliceType,
-			Func: r.nilToSlice,
-		},
-
-		// struct
-		{
-			From: MapType,
-			To:   StructType,
-			Func: r.mapToStruct,
-		},
-		{
-			From: StructType,
-			To:   StructType,
-			Func: r.structToStruct,
-		},
 
 		// time
 		MustMakeRecipe(r.intToTime),
@@ -318,5 +271,53 @@ func getStdRecipes() []Recipe {
 		MustMakeRecipe(r.float64ToUint64),
 		MustMakeRecipe(r.stringToUint64),
 		MustMakeRecipe(r.timeToUint64),
+
+		// map
+		{
+			From: MapType,
+			To:   MapType,
+			Func: r.mapToMap,
+		},
+		{
+			From: StructType,
+			To:   MapType,
+			Func: r.structToMap,
+		},
+
+		// struct to string
+		{
+			From: StructType,
+			To:   reflect.TypeOf(&s),
+			Func: r.structToString,
+		},
+
+		// slice
+		{
+			From: reflect.TypeOf(""),
+			To:   SliceType,
+			Func: r.stringToSlice,
+		},
+		{
+			From: SliceType,
+			To:   SliceType,
+			Func: r.sliceToSlice,
+		},
+		{
+			From: NilType,
+			To:   SliceType,
+			Func: r.nilToSlice,
+		},
+
+		// struct
+		{
+			From: MapType,
+			To:   StructType,
+			Func: r.mapToStruct,
+		},
+		{
+			From: StructType,
+			To:   StructType,
+			Func: r.structToStruct,
+		},
 	}
 }

--- a/string.go
+++ b/string.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"time"
 )
 
 func (stdRecipes) intToString(c Converter, in int, out *string) error {
@@ -173,6 +174,11 @@ func (stdRecipes) uint64SliceToString(c Converter, in []uint64, out *string) err
 		sb.WriteRune(rune(i))
 	}
 	*out = sb.String()
+	return nil
+}
+
+func (stdRecipes) timeToString(c Converter, in time.Time, out *string) error {
+	*out = in.String()
 	return nil
 }
 

--- a/uint.go
+++ b/uint.go
@@ -2,6 +2,7 @@ package convert
 
 import (
 	"strconv"
+	"time"
 )
 
 func (stdRecipes) intToUint(c Converter, in int, out *uint) error {
@@ -72,5 +73,9 @@ func (stdRecipes) stringToUint(c Converter, in string, out *uint) error {
 		return err
 	}
 	*out = uint(i)
+	return nil
+}
+func (stdRecipes) timeToUint(c Converter, in time.Time, out *uint) error {
+	*out = uint(in.Unix())
 	return nil
 }

--- a/uint16.go
+++ b/uint16.go
@@ -2,6 +2,7 @@ package convert
 
 import (
 	"strconv"
+	"time"
 )
 
 func (stdRecipes) intToUint16(c Converter, in int, out *uint16) error {
@@ -72,5 +73,9 @@ func (stdRecipes) stringToUint16(c Converter, in string, out *uint16) error {
 		return err
 	}
 	*out = uint16(i)
+	return nil
+}
+func (stdRecipes) timeToUint16(c Converter, in time.Time, out *uint16) error {
+	*out = uint16(in.Unix())
 	return nil
 }

--- a/uint16_test.go
+++ b/uint16_test.go
@@ -3,6 +3,8 @@ package convert_test
 import (
 	"testing"
 
+	"time"
+
 	"github.com/Eun/go-convert/internal/testhelpers"
 )
 
@@ -48,6 +50,8 @@ func TestUint16(t *testing.T) {
 		{[]string{"H", "e", "l", "l", "o"}, uint16(0), uint16(0), "unable to convert []string to uint16: no recipe", nil},
 		// struct
 		{struct{}{}, uint16(0), uint16(0), "unable to convert struct {} to uint16: no recipe", nil},
+		// time
+		{time.Unix(10, 10), uint16(10), uint16(10), "", nil},
 	}
 
 	for i, test := range tests {

--- a/uint32.go
+++ b/uint32.go
@@ -2,6 +2,7 @@ package convert
 
 import (
 	"strconv"
+	"time"
 )
 
 func (stdRecipes) intToUint32(c Converter, in int, out *uint32) error {
@@ -72,5 +73,9 @@ func (stdRecipes) stringToUint32(c Converter, in string, out *uint32) error {
 		return err
 	}
 	*out = uint32(i)
+	return nil
+}
+func (stdRecipes) timeToUint32(c Converter, in time.Time, out *uint32) error {
+	*out = uint32(in.Unix())
 	return nil
 }

--- a/uint32_test.go
+++ b/uint32_test.go
@@ -3,6 +3,8 @@ package convert_test
 import (
 	"testing"
 
+	"time"
+
 	"github.com/Eun/go-convert/internal/testhelpers"
 )
 
@@ -48,6 +50,8 @@ func TestUint32(t *testing.T) {
 		{[]string{"H", "e", "l", "l", "o"}, uint32(0), uint32(0), "unable to convert []string to uint32: no recipe", nil},
 		// struct
 		{struct{}{}, uint32(0), uint32(0), "unable to convert struct {} to uint32: no recipe", nil},
+		// time
+		{time.Unix(10, 10), uint32(10), uint32(10), "", nil},
 	}
 
 	for i, test := range tests {

--- a/uint64.go
+++ b/uint64.go
@@ -2,6 +2,7 @@ package convert
 
 import (
 	"strconv"
+	"time"
 )
 
 func (stdRecipes) intToUint64(c Converter, in int, out *uint64) error {
@@ -72,5 +73,9 @@ func (stdRecipes) stringToUint64(c Converter, in string, out *uint64) error {
 		return err
 	}
 	*out = uint64(i)
+	return nil
+}
+func (stdRecipes) timeToUint64(c Converter, in time.Time, out *uint64) error {
+	*out = uint64(in.Unix())
 	return nil
 }

--- a/uint64_test.go
+++ b/uint64_test.go
@@ -3,6 +3,8 @@ package convert_test
 import (
 	"testing"
 
+	"time"
+
 	"github.com/Eun/go-convert/internal/testhelpers"
 )
 
@@ -48,6 +50,8 @@ func TestUint64(t *testing.T) {
 		{[]string{"H", "e", "l", "l", "o"}, uint64(0), uint64(0), "unable to convert []string to uint64: no recipe", nil},
 		// struct
 		{struct{}{}, uint64(0), uint64(0), "unable to convert struct {} to uint64: no recipe", nil},
+		// time
+		{time.Unix(10, 10), uint64(10), uint64(10), "", nil},
 	}
 
 	for i, test := range tests {

--- a/uint8.go
+++ b/uint8.go
@@ -2,6 +2,7 @@ package convert
 
 import (
 	"strconv"
+	"time"
 )
 
 func (stdRecipes) intToUint8(c Converter, in int, out *uint8) error {
@@ -72,5 +73,10 @@ func (stdRecipes) stringToUint8(c Converter, in string, out *uint8) error {
 		return err
 	}
 	*out = uint8(i)
+	return nil
+}
+
+func (stdRecipes) timeToUint8(c Converter, in time.Time, out *uint8) error {
+	*out = uint8(in.Unix())
 	return nil
 }

--- a/uint8_test.go
+++ b/uint8_test.go
@@ -3,6 +3,8 @@ package convert_test
 import (
 	"testing"
 
+	"time"
+
 	"github.com/Eun/go-convert/internal/testhelpers"
 )
 
@@ -48,6 +50,8 @@ func TestUint8(t *testing.T) {
 		{[]string{"H", "e", "l", "l", "o"}, uint8(0), uint8(0), "unable to convert []string to uint8: no recipe", nil},
 		// struct
 		{struct{}{}, uint8(0), uint8(0), "unable to convert struct {} to uint8: no recipe", nil},
+		// time
+		{time.Unix(10, 10), uint8(10), uint8(10), "", nil},
 	}
 
 	for i, test := range tests {

--- a/uint_test.go
+++ b/uint_test.go
@@ -3,6 +3,8 @@ package convert_test
 import (
 	"testing"
 
+	"time"
+
 	"github.com/Eun/go-convert/internal/testhelpers"
 )
 
@@ -47,6 +49,8 @@ func TestUint(t *testing.T) {
 		{[]string{"H", "e", "l", "l", "o"}, uint(0), uint(0), "unable to convert []string to uint: no recipe", nil},
 		// struct
 		{struct{}{}, uint(0), uint(0), "unable to convert struct {} to uint: no recipe", nil},
+		// time
+		{time.Unix(10, 10), uint(10), uint(10), "", nil},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
so we don't accidentally call them before an standart recipe

+ add time.Time conversions to (u)int