### PR TITLE
chore(CI): mark dependabot pull requests as chore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     schedule:
       interval: daily
       time: "04:00"
-    commit_message:
+    commit-message:
       prefix: "chore"
     labels:
       - "dependencies"
@@ -19,7 +19,7 @@ updates:
     schedule:
       interval: "daily"
       time: "04:00"
-    commit_message:
+    commit-message:
       prefix: "chore"
     labels:
       - "dependencies"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,12 @@ updates:
     schedule:
       interval: daily
       time: "04:00"
+    commit_message:
+      prefix: "chore"
+    labels:
+      - "dependencies"
+      - "go"
+      - "chore"
 
   - package-ecosystem: "github-actions"
     open-pull-requests-limit: 10
@@ -13,4 +19,10 @@ updates:
     schedule:
       interval: "daily"
       time: "04:00"
+    commit_message:
+      prefix: "chore"
+    labels:
+      - "dependencies"
+      - "github_actions"
+      - "chore"
 


### PR DESCRIPTION
## Description

dependabot pull requests should be marked as chore by default.

### Checklist
- [x] The title starts either with `feat(area)`, `fix(area)`, or `chore(area)`
  - `feat` should be used if this pull request implements a new feature
  - `fix` should be used if this pull request fixes a bug
  - `chore` should be used for maintenance changes
  - `area` should be describing the relevant section of the project
- [x] ran `go mod tidy`
- [x] ran `go mod vendor`
- [x] ran `docker run --rm -ti -v $PWD:/workspace -w /workspace eunts/minigo:latest --template -o /workspace/README.md /workspace/README.md.template`

